### PR TITLE
Change langcode to language

### DIFF
--- a/pathauto.inc
+++ b/pathauto.inc
@@ -177,8 +177,8 @@ function pathauto_cleanstring($string, array $options = array()) {
   }
 
   $langcode = NULL;
-  if (!empty($options['language']->$langcode)) {
-    $langcode = $options['language']->$langcode;
+  if (!empty($options['language']->$language)) {
+    $langcode = $options['language']->$language;
   }
   elseif (!empty($options['langcode'])) {
     $langcode = $options['langcode'];


### PR DESCRIPTION
Resolves #6 

I'm not entirely sure this is the correct fix here, but it does resolve the problem in a clean Backdrop install when creating content.

It would seem that 'langcode' was changed to 'language' in the object, but I could be mistaken. I couldn't find anything about it in the [Change Records](https://api.backdropcms.org/change-records).
